### PR TITLE
Fix codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,13 +26,15 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-20.04]
-                rust_toolchain: [nightly-2023-05-09]
+                rust_toolchain: [nightly-2023-05-22]
+                rust_target: [x86_64-unknown-linux-gnu, wasm32-wasi]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/checkout@v3
             - uses: actions-rs/toolchain@v1
               with:
                   toolchain: ${{ matrix.rust_toolchain }}
+                  target: ${{ matrix.rust_target }}
                   override: true
 
             - uses: Swatinem/rust-cache@v2
@@ -44,8 +46,34 @@ jobs:
             # default: ". -> target"
             #   workspaces: ""
             - name: Build
-              run: cargo build --verbose
+              run: cargo build --verbose --target ${{ matrix.rust_target }}
+            - name: Install cargo-wasi
+              if: matrix.rust_target == 'wasm32-wasi'
+              run: cargo install cargo-wasi
+            - name: Install wasmtime
+              if: matrix.rust_target == 'wasm32-wasi'
+              run: |
+                  curl https://wasmtime.dev/install.sh -sSf | bash
+                  echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
             - name: Run tests
               run: |
-                  cargo test --verbose
-
+                  if [ "${{ matrix.rust_target }}" == "wasm32-wasi" ]; then
+                      cargo wasi test --verbose --target ${{ matrix.rust_target }}
+                  else
+                      cargo test --verbose --target ${{ matrix.rust_target }}
+                  fi
+              env:
+                  CARGO_INCREMENTAL: "0"
+                  RUSTFLAGS: ${{ matrix.rust_target == 'x86_64-unknown-linux-gnu' && '-Zprofile -Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests' || '' }}
+                  RUSTDOCFLAGS: ${{ matrix.rust_target == 'x86_64-unknown-linux-gnu' && '-Zprofile -Cinstrument-coverage -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests' || '' }}
+            - name: rust-grcov
+              if: matrix.rust_target == 'x86_64-unknown-linux-gnu'
+              id: rs-cov
+              uses: actions-rs/grcov@v0.1.6
+            # Needs to be public first
+            # - name: Codecov
+            #   uses: codecov/codecov-action@v3.1.0
+            #   with:
+            #       verbose: true
+            #       fail_ci_if_error: true
+            #       files: ${{ steps.rs-cov.outputs.report }}


### PR DESCRIPTION
 Fix issue with code coverage. Multiple hyphens in crate names was breaking their regex for finding the coverage files. Just needed to upgrade to the new bugfix release.