### PR TITLE
Make envelope actually configurable

### DIFF
--- a/pro-serde-versioned-derive/src/lib.rs
+++ b/pro-serde-versioned-derive/src/lib.rs
@@ -75,7 +75,8 @@ pub fn versioned_serialize(input: TokenStream) -> TokenStream {
         )*
 
         impl #impl_generics ::pro_serde_versioned::VersionedSerialize for #name #ty_generics #where_clause {
-            fn to_envelope<F: ::pro_serde_versioned::SerializeFormat>(&self) -> Result<::pro_serde_versioned::VersionedEnvelope<F>, F::Error> {
+            type VersionedEnvelope<A: Serialize> = ::pro_serde_versioned::VersionedEnvelope<A>;
+            fn to_envelope<F: ::pro_serde_versioned::SerializeFormat>(&self) -> Result<Self::VersionedEnvelope<F>, F::Error> {
                 match self {
                     #(
                         #name::#variant_names(value) => {
@@ -114,6 +115,7 @@ pub fn versioned_deserialize(input: TokenStream) -> TokenStream {
 
     quote! {
         impl #impl_generics ::pro_serde_versioned::VersionedDeserialize for #name #ty_generics #where_clause {
+            type VersionedEnvelope<'a, F: Deserialize<'a>> = ::pro_serde_versioned::VersionedEnvelope<F>;
             fn from_envelope<'a, F: ::pro_serde_versioned::DeserializeFormat + Deserialize<'a>>(
                 envelope: &::pro_serde_versioned::VersionedEnvelope<F>,
             ) -> Result<Self, F::Error> {

--- a/pro-serde-versioned/src/lib.rs
+++ b/pro-serde-versioned/src/lib.rs
@@ -34,7 +34,9 @@ pub trait Upgrade<To> {
 
 /// Allows for serializing to any supported format.
 pub trait VersionedSerialize {
-    fn to_envelope<F>(&self) -> Result<VersionedEnvelope<F>, F::Error>
+    type VersionedEnvelope<F: Serialize>: Serialize;
+
+    fn to_envelope<F>(&self) -> Result<Self::VersionedEnvelope<F>, F::Error>
     where
         F: SerializeFormat;
 
@@ -48,7 +50,9 @@ pub trait VersionedSerialize {
 
 /// Allows for serializing from any supported format.
 pub trait VersionedDeserialize: Sized + Clone {
-    fn from_envelope<'a, F>(data: &VersionedEnvelope<F>) -> Result<Self, F::Error>
+    type VersionedEnvelope<'a, F: Deserialize<'a>>: Deserialize<'a>;
+
+    fn from_envelope<'a, F>(data: &Self::VersionedEnvelope<'a, F>) -> Result<Self, F::Error>
     where
         F: DeserializeFormat + Deserialize<'a>;
 
@@ -56,7 +60,7 @@ pub trait VersionedDeserialize: Sized + Clone {
     where
         F: DeserializeFormat + Deserialize<'a>,
     {
-        let envelope: VersionedEnvelope<F> = F::deserialize_format(data)?;
+        let envelope: Self::VersionedEnvelope<'a, F> = F::deserialize_format(data)?;
         Self::from_envelope(&envelope)
     }
 }


### PR DESCRIPTION
Adds `VersionedEnvelope<'a, F>` generic associated type to allow customization of the version wrapper format.